### PR TITLE
ADD pages and routes for site

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,10 @@ Website for the 2015 Madison PHP Conference
 - Grab the project `git clone https://github.com/madisonphp/conference2015.git`
 - Move into the project `cd conference2015`
 - Install packages and dependencies `composer install`
-- Direct requests to `web/index.php`
+- Set `web/` as your public folder
 
 ## Resources
 
-[Silex](http://silex.sensiolabs.org/documentation)
-[Twig](http://twig.sensiolabs.org/)
+* [Bootstrap](http://getbootstrap.com/css/)
+* [Twig](http://twig.sensiolabs.org/)
+* [Silex](http://silex.sensiolabs.org/documentation)

--- a/views/layout.twig.html
+++ b/views/layout.twig.html
@@ -4,11 +4,13 @@
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>Madison PHP Conference 2015</title>
+        <title>{% block title %}Home{% endblock %} // Madison PHP Conference 2015</title>
+        <meta name="description" content="{% block meta_description %}{% endblock %}">
 
         <link href='http://fonts.googleapis.com/css?family=Montserrat:400,700' rel='stylesheet' type='text/css'>
         <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
         <link href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css" rel="stylesheet">
+        <link href="/assets/css/layout.css" rel="stylesheet">
         <link href="/assets/css/style.css" rel="stylesheet">
 
         <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
@@ -19,9 +21,10 @@
         <![endif]-->
     </head>
     <body>
+
         {% include "includes/nav.twig.html" %}
 
-        <div class="jumbotron text-center">
+        <div class="jumbotron text-center" role="banner">
             <div class="container">
                 <h1><img src="/assets/images/conf-logo.png" alt="Madison PHP Conference"></h1>
                 <h2>Saturday, November 14th, 2015</h2>
@@ -32,6 +35,26 @@
                 </div>
             </div>
         </div>
+
+        <div class="maincontent" role="main">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-12">
+                        {% block content %}{% endblock %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <footer role="contentinfo">
+            <div class="container">
+                <div class="row">
+                    <div class="col-md-12">
+                        <p>Copyright &copy; 2015 Madison PHP</p>
+                    </div>
+                </div>
+            </div>
+        </footer>
 
         <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>

--- a/views/pages/home.html
+++ b/views/pages/home.html
@@ -1,0 +1,11 @@
+{% extends layout %}
+
+{% block title %}Home{% endblock %}
+
+{% block meta_description %}
+Join us on Saturday, September 14th, 2015 for a one day, three track conference in Madison, Wisconsin that focuses on PHP and related web technologies.
+{% endblock %}
+ 
+{% block content %}
+
+{% endblock %}

--- a/views/pages/hotel.html
+++ b/views/pages/hotel.html
@@ -1,0 +1,14 @@
+{% extends layout %}
+
+{% block title %}Hotel{% endblock %}
+
+{% block meta_description %}
+2015 Madison PHP Conference Hotel
+{% endblock %}
+ 
+{% block content %}
+  <h1>Hotel</h1>
+  <p>
+    Enim direct trade nihil sed, tilde asymmetrical officia esse accusamus. Heirloom cliche fap, slow-carb Etsy consequat gluten-free deep v cupidatat Carles drinking vinegar nostrud Kickstarter ad tilde. Ullamco ethical salvia meggings odio, placeat authentic banjo four loko roof party Intelligentsia. Tousled occupy flannel aliquip Brooklyn esse actually four dollar toast, fugiat try-hard officia Marfa Bushwick four loko vegan.
+  </p>
+{% endblock %}

--- a/views/pages/schedule.html
+++ b/views/pages/schedule.html
@@ -1,0 +1,14 @@
+{% extends layout %}
+
+{% block title %}Schedule{% endblock %}
+
+{% block meta_description %}
+2015 Madison PHP Conference Schedule
+{% endblock %}
+ 
+{% block content %}
+  <h1>Schedule</h1>
+  <p>
+    Enim direct trade nihil sed, tilde asymmetrical officia esse accusamus. Heirloom cliche fap, slow-carb Etsy consequat gluten-free deep v cupidatat Carles drinking vinegar nostrud Kickstarter ad tilde. Ullamco ethical salvia meggings odio, placeat authentic banjo four loko roof party Intelligentsia. Tousled occupy flannel aliquip Brooklyn esse actually four dollar toast, fugiat try-hard officia Marfa Bushwick four loko vegan.
+  </p>
+{% endblock %}

--- a/views/pages/speakers.html
+++ b/views/pages/speakers.html
@@ -1,0 +1,14 @@
+{% extends layout %}
+
+{% block title %}Speakers{% endblock %}
+
+{% block meta_description %}
+2015 Madison PHP Conference Speakers
+{% endblock %}
+ 
+{% block content %}
+  <h1>Speakers</h1>
+  <p>
+    Enim direct trade nihil sed, tilde asymmetrical officia esse accusamus. Heirloom cliche fap, slow-carb Etsy consequat gluten-free deep v cupidatat Carles drinking vinegar nostrud Kickstarter ad tilde. Ullamco ethical salvia meggings odio, placeat authentic banjo four loko roof party Intelligentsia. Tousled occupy flannel aliquip Brooklyn esse actually four dollar toast, fugiat try-hard officia Marfa Bushwick four loko vegan.
+  </p>
+{% endblock %}

--- a/views/pages/sponsors.html
+++ b/views/pages/sponsors.html
@@ -1,0 +1,14 @@
+{% extends layout %}
+
+{% block title %}Sponsors{% endblock %}
+
+{% block meta_description %}
+2015 Madison PHP Conference Sponsors
+{% endblock %}
+ 
+{% block content %}
+  <h1>Sponsors</h1>
+  <p>
+    Enim direct trade nihil sed, tilde asymmetrical officia esse accusamus. Heirloom cliche fap, slow-carb Etsy consequat gluten-free deep v cupidatat Carles drinking vinegar nostrud Kickstarter ad tilde. Ullamco ethical salvia meggings odio, placeat authentic banjo four loko roof party Intelligentsia. Tousled occupy flannel aliquip Brooklyn esse actually four dollar toast, fugiat try-hard officia Marfa Bushwick four loko vegan.
+  </p>
+{% endblock %}

--- a/views/pages/venue.html
+++ b/views/pages/venue.html
@@ -1,0 +1,14 @@
+{% extends layout %}
+
+{% block title %}Venue{% endblock %}
+
+{% block meta_description %}
+2015 Madison PHP Conference Venue
+{% endblock %}
+ 
+{% block content %}
+  <h1>Venue</h1>
+  <p>
+    Enim direct trade nihil sed, tilde asymmetrical officia esse accusamus. Heirloom cliche fap, slow-carb Etsy consequat gluten-free deep v cupidatat Carles drinking vinegar nostrud Kickstarter ad tilde. Ullamco ethical salvia meggings odio, placeat authentic banjo four loko roof party Intelligentsia. Tousled occupy flannel aliquip Brooklyn esse actually four dollar toast, fugiat try-hard officia Marfa Bushwick four loko vegan.
+  </p>
+{% endblock %}

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -1,0 +1,7 @@
+<IfModule mod_rewrite.c>
+    Options -MultiViews
+
+    RewriteEngine On
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteRule ^ index.php [QSA,L]
+</IfModule>

--- a/web/index.php
+++ b/web/index.php
@@ -2,20 +2,93 @@
 require_once __DIR__.'/../vendor/autoload.php';
 
 $app = new Silex\Application();
-$app['debug'] = true;
 
+// turn off debug mode for live site
+$app['debug'] = (gethostname() == 'web01') ? false : true;
+
+// register twig
 $app->register(new Silex\Provider\TwigServiceProvider(), array(
     'twig.path' => __DIR__ . '/../views',
 ));
 
-$app['nav'] = array(
-    'Home'  => '/',
+// draft site
+$draft_menu = array(
+    'Home' => '/',
+    'Schedule' => '/schedule/',
+    'Speakers' => '/speakers/',
+    'Venue' => '/venue/',
+    'Hotel' => '/hotel/',
+    'Sponsors' => '/sponsors/',
+    'Contact' => 'http://contact.madisonphpconference.com'
 );
 
+// live site
+$published_menu = array(
+    'Home' => '/',
+);
+
+// set nav
+if (isset($_GET['preview'])) {
+    foreach ($draft_menu as $key => $val) {
+        if ($key == 'Contact') continue;
+        $draft_menu[$key] = $val . '?preview';
+    }
+    $app['nav'] = $draft_menu;
+} else {
+    $app['nav'] = $published_menu;
+}
+
+// use layout templates
+$app->before(function () use ($app) {
+    $app['twig']->addGlobal('layout', null);
+    $app['twig']->addGlobal('layout', $app['twig']->loadTemplate('layout.twig.html'));
+});
+
+// route for home page
 $app->get('/', function() use($app) {
-    return $app['twig']->render('layout.twig.html', array(
+    return $app['twig']->render('pages/home.html', array(
         'nav' => $app['nav'],
         'active' => 'Home',
+    ));
+});
+
+// route for schedule
+$app->get('/schedule/', function() use($app) {
+    return $app['twig']->render('pages/schedule.html', array(
+        'nav' => $app['nav'],
+        'active' => 'Schedule',
+    ));
+});
+
+// route for speakers
+$app->get('/speakers/', function() use($app) {
+    return $app['twig']->render('pages/speakers.html', array(
+        'nav' => $app['nav'],
+        'active' => 'Speakers',
+    ));
+});
+
+// route for venue
+$app->get('/venue/', function() use($app) {
+    return $app['twig']->render('pages/venue.html', array(
+        'nav' => $app['nav'],
+        'active' => 'Venue',
+    ));
+});
+
+// route for hotel
+$app->get('/hotel/', function() use($app) {
+    return $app['twig']->render('pages/hotel.html', array(
+        'nav' => $app['nav'],
+        'active' => 'Hotel',
+    ));
+});
+
+// route for sponsors
+$app->get('/sponsors/', function() use($app) {
+    return $app['twig']->render('pages/sponsors.html', array(
+        'nav' => $app['nav'],
+        'active' => 'Sponsors',
     ));
 });
 


### PR DESCRIPTION
- Created routes and files for all the pages from the 2014 site
- Page content can be edited in the /views/pages/ folder
- Added option to load a draft menu by appending "?preview"
- Added .htaccess to properly serve routes and assets
- Setup page templates to extend master layout
